### PR TITLE
Fix missing splinter cell job categories

### DIFF
--- a/lua/autorun/splinter_cell_loader.lua
+++ b/lua/autorun/splinter_cell_loader.lua
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- Splinter Cell Vision Goggles - Autorun Loader
+-- ============================================================================
+-- This file ensures proper loading order for DarkRP integration
+-- ============================================================================
+
+-- Only run on server
+if SERVER then
+    -- Print loading message
+    print("[AUTORUN] Loading Splinter Cell Vision Goggles...")
+    
+    -- Ensure weapon is loaded first
+    if file.Exists("lua/weapons/splinter_cell_vision.lua", "GAME") then
+        include("weapons/splinter_cell_vision.lua")
+        print("[AUTORUN] Weapon file loaded: splinter_cell_vision.lua")
+    else
+        print("[ERROR] Weapon file not found: weapons/splinter_cell_vision.lua")
+    end
+    
+    -- Load DarkRP configuration after a delay to ensure DarkRP is ready
+    timer.Simple(0.5, function()
+        if DarkRP then
+            if file.Exists("lua/darkrp_customthings/splinter_cell_config.lua", "GAME") then
+                include("darkrp_customthings/splinter_cell_config.lua")
+                print("[AUTORUN] DarkRP configuration loaded: splinter_cell_config.lua")
+            else
+                print("[ERROR] DarkRP config file not found: darkrp_customthings/splinter_cell_config.lua")
+            end
+        else
+            print("[WARNING] DarkRP not loaded yet, retrying in 1 second...")
+            timer.Simple(1, function()
+                if DarkRP then
+                    include("darkrp_customthings/splinter_cell_config.lua")
+                    print("[AUTORUN] DarkRP configuration loaded (delayed): splinter_cell_config.lua")
+                else
+                    print("[ERROR] DarkRP still not loaded! Manual configuration required.")
+                end
+            end)
+        end
+    end)
+    
+    print("[AUTORUN] Splinter Cell Vision Goggles autorun complete!")
+end

--- a/lua/darkrp_customthings/splinter_cell_config.lua
+++ b/lua/darkrp_customthings/splinter_cell_config.lua
@@ -12,9 +12,16 @@ if not DarkRP then
 end
 
 -- Ensure the weapon exists before adding to DarkRP
-timer.Simple(1, function()
+timer.Simple(2, function()
     if not weapons.Get("splinter_cell_vision") then
         print("[WARNING] splinter_cell_vision weapon not found! Make sure the weapon file is loaded.")
+        print("[INFO] Attempting to reload weapon...")
+        -- Force weapon registration
+        if SERVER then
+            include("weapons/splinter_cell_vision.lua")
+        end
+    else
+        print("[SUCCESS] splinter_cell_vision weapon loaded successfully!")
     end
 end)
 
@@ -25,6 +32,20 @@ end)
 -- They are NOT available for purchase through F4 menu or shipments.
 -- Only players with Splinter Cell jobs can use these advanced vision systems.
 -- ============================================================================
+
+-- ============================================================================
+-- CATEGORIES
+-- ============================================================================
+
+-- Create the Special Forces category
+DarkRP.createCategory{
+    name = "Special Forces",
+    categorises = "jobs",
+    startExpanded = true,
+    color = Color(0, 150, 0, 255),
+    canSee = function(ply) return true end,
+    sortOrder = 100,
+}
 
 -- ============================================================================
 -- CUSTOM JOBS

--- a/lua/weapons/splinter_cell_vision.lua
+++ b/lua/weapons/splinter_cell_vision.lua
@@ -4,6 +4,7 @@ SWEP.PrintName = "Splinter Cell Vision Goggles"
 SWEP.Author = "DarkRP Enhanced"
 SWEP.Instructions = "Press N to toggle vision, T to cycle modes | DarkRP Compatible"
 SWEP.Category = "DarkRP Special"
+SWEP.ClassName = "splinter_cell_vision"
 
 SWEP.Spawnable = true
 SWEP.AdminOnly = false


### PR DESCRIPTION
Fix DarkRP category and weapon loading errors for the Splinter Cell addon.

The "Special Forces" category was undefined, causing job creation failures. The `splinter_cell_vision` weapon was not recognized due to a missing `SWEP.ClassName` and potential loading order conflicts, which are now resolved by an explicit autorun loader.

---
<a href="https://cursor.com/background-agent?bcId=bc-a697610b-630f-44b8-b9b1-2a773728ff29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a697610b-630f-44b8-b9b1-2a773728ff29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

