### PR TITLE
Fix splinter cell vision weapon nil value

### DIFF
--- a/lua/autorun/splinter_cell_loader.lua
+++ b/lua/autorun/splinter_cell_loader.lua
@@ -9,10 +9,9 @@ if SERVER then
     -- Print loading message
     print("[AUTORUN] Loading Splinter Cell Vision Goggles...")
     
-    -- Ensure weapon is loaded first
+    -- Check if weapon file exists (don't include directly - let GMod's weapon system handle it)
     if file.Exists("lua/weapons/splinter_cell_vision.lua", "GAME") then
-        include("weapons/splinter_cell_vision.lua")
-        print("[AUTORUN] Weapon file loaded: splinter_cell_vision.lua")
+        print("[AUTORUN] Weapon file found: splinter_cell_vision.lua")
     else
         print("[ERROR] Weapon file not found: weapons/splinter_cell_vision.lua")
     end

--- a/lua/darkrp_customthings/splinter_cell_config.lua
+++ b/lua/darkrp_customthings/splinter_cell_config.lua
@@ -14,12 +14,8 @@ end
 -- Ensure the weapon exists before adding to DarkRP
 timer.Simple(2, function()
     if not weapons.Get("splinter_cell_vision") then
-        print("[WARNING] splinter_cell_vision weapon not found! Make sure the weapon file is loaded.")
-        print("[INFO] Attempting to reload weapon...")
-        -- Force weapon registration
-        if SERVER then
-            include("weapons/splinter_cell_vision.lua")
-        end
+        print("[WARNING] splinter_cell_vision weapon not found! Make sure the weapon file is properly placed in lua/weapons/")
+        print("[INFO] The weapon should load automatically through GMod's weapon system.")
     else
         print("[SUCCESS] splinter_cell_vision weapon loaded successfully!")
     end


### PR DESCRIPTION
Remove direct weapon file inclusions from autorun and DarkRP config to fix `SWEP` nil errors.

The `SWEP` table was `nil` because `splinter_cell_vision.lua` was being `include()`d directly, bypassing GMod's weapon system which is responsible for initializing `SWEP`. By removing these direct includes, GMod's native weapon loading mechanism can handle the file correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-93072b3e-10c5-45a8-a6a7-b5337e2f235f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93072b3e-10c5-45a8-a6a7-b5337e2f235f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

