### PR TITLE
Fix goggles in darkrp gamemode

### DIFF
--- a/DARKRP_FIX_SUMMARY.md
+++ b/DARKRP_FIX_SUMMARY.md
@@ -1,0 +1,67 @@
+# DarkRP Goggles Fix Summary
+
+## Issues Identified and Fixed
+
+### 1. **Client-Server Synchronization Problems**
+- **Problem**: Vision effects were purely client-side, causing desync in DarkRP
+- **Solution**: Added proper server-side state management using NWVars
+- **Changes**: 
+  - Added `SetNWBool("VisionActive")` and `SetNWInt("VisionMode")` for server state
+  - Client now syncs with server state in `Think()` function
+
+### 2. **Missing Network Communication** 
+- **Problem**: No networking between client and server for DarkRP validation
+- **Solution**: Added proper net messages for vision control
+- **Changes**:
+  - Added `SC_VisionToggle`, `SC_VisionModeChange`, `SC_VisionState` net messages
+  - Server validates permissions before allowing vision changes
+
+### 3. **DarkRP Permission System**
+- **Problem**: No job-based permission checking for vision access
+- **Solution**: Added `CanUseVision()` function with DarkRP job validation
+- **Changes**:
+  - Checks if player's current job has `splinter_cell_vision` weapon
+  - Fallback to admin permission check
+
+### 4. **Weapon State Management**
+- **Problem**: Vision state not properly handled during weapon deploy/holster
+- **Solution**: Enhanced Deploy/Holster functions with DarkRP compatibility
+- **Changes**:
+  - Auto-sync client state on weapon deploy
+  - Clean server state on weapon holster
+  - Proper cleanup in OnRemove
+
+### 5. **Job Integration Hooks**
+- **Problem**: No automatic weapon distribution when joining Splinter Cell jobs
+- **Solution**: Added DarkRP hooks for seamless job integration
+- **Changes**:
+  - `playerBoughtCustomJob` hook gives weapon automatically
+  - `OnPlayerChangedTeam` hook removes weapon when leaving job
+
+## How to Test
+
+1. **Join DarkRP server with this addon installed**
+2. **Become Splinter Cell Operative job** (F4 menu → Special Forces → Splinter Cell Operative)
+3. **Verify you receive the goggles automatically**
+4. **Test vision controls**:
+   - Press `N` to toggle vision on/off
+   - Press `T` to cycle between vision modes
+   - Use chat commands `/togglevision` and `/cyclevision` as backup
+5. **Change to a different job and verify goggles are removed**
+
+## Key Improvements
+
+- ✅ **Server-side validation** ensures DarkRP compatibility
+- ✅ **Job-based permissions** prevent unauthorized access
+- ✅ **Automatic weapon management** on job changes
+- ✅ **Proper state synchronization** between client and server
+- ✅ **Fallback chat commands** for additional reliability
+- ✅ **Admin override** capabilities maintained
+
+## Files Modified
+
+1. `lua/weapons/splinter_cell_vision.lua` - Main weapon file with networking fixes
+2. `lua/darkrp_customthings/splinter_commands.lua` - Added DarkRP integration hooks
+3. `lua/darkrp_customthings/jobs.lua` - Job definitions (unchanged, working correctly)
+
+The goggles should now work perfectly in DarkRP while maintaining job restrictions and proper server-client synchronization.


### PR DESCRIPTION
Integrate Splinter Cell goggles with DarkRP to enable their functionality through server-side state management and job-based permissions.

Previously, the goggles' vision effects were entirely client-side, causing desynchronization and lack of DarkRP job-based permission enforcement, which prevented them from working correctly in the gamemode.

---
<a href="https://cursor.com/background-agent?bcId=bc-74b9d434-ab79-4306-b889-c0885addf1c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74b9d434-ab79-4306-b889-c0885addf1c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

